### PR TITLE
core: allow disabling tests, ui, and wallet when building

### DIFF
--- a/pkgs/dogecoin-core/default.nix
+++ b/pkgs/dogecoin-core/default.nix
@@ -1,4 +1,13 @@
-{ pkgs, stdenv, fetchurl, lib, ... }:
+{
+  pkgs ? import <nixpkgs> {},
+  stdenv ? pkgs.stdenv,
+  fetchurl ? pkgs.fetchurl,
+  lib ? pkgs.lib,
+  disableWallet ? false,
+  disableGUI ? false,
+  disableTests ? false,
+  ...
+}:
 
 stdenv.mkDerivation rec {
   pname = "dogecoin-core";
@@ -12,7 +21,10 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--with-incompatible-bdb"
     "--with-boost-libdir=${pkgs.boost}/lib"
-  ];
+  ]
+  ++ lib.optional disableWallet "--disable-wallet"
+  ++ lib.optional disableGUI "--with-gui=no"
+  ++ lib.optional disableTests "--disable-tests";
 
   nativeBuildInputs = [
     pkgs.pkg-config


### PR DESCRIPTION
This adds `disableWallet`, `disableGUI`, and `disableTests` options for building core.

When all 3 are set (for use in a pup, for example), this drops build time from `~9` to `4` minutes on my M3 MBP.


Previously:

```
$ time nix-build ./pkgs/dogecoin-core/default.nix
...
real	8m53.191s
user	0m0.376s
sys	0m0.239s
```

Now:

```
$ time nix-build ./pkgs/dogecoin-core/default.nix --arg disableWallet true --arg disableGUI true --arg disableTests true
...
real	4m0.874s
user	0m0.336s
sys	0m0.110s

```

