### PR TITLE
Update packages to use default nix things

### DIFF
--- a/pkgs/dkm/default.nix
+++ b/pkgs/dkm/default.nix
@@ -1,8 +1,6 @@
 {
   pkgs ? import <nixpkgs> {},
   lib ? pkgs.lib,
-  stdenv ? pkgs.stdenv,
-  fetchurl ? pkgs.fetchurl,
   buildGoModule ? pkgs.buildGoModule,
   ...
 }:

--- a/pkgs/dogeboxd/default.nix
+++ b/pkgs/dogeboxd/default.nix
@@ -1,8 +1,6 @@
 {
   pkgs ? import <nixpkgs> {},
   lib ? pkgs.lib,
-  stdenv ? pkgs.stdenv,
-  fetchurl ? pkgs.fetchurl,
   buildGoModule ? pkgs.buildGoModule,
   ...
 }:

--- a/pkgs/dogemap/default.nix
+++ b/pkgs/dogemap/default.nix
@@ -1,4 +1,9 @@
-{ lib, pkgs, stdenv, fetchurl, buildGoModule, ... }:
+{
+  pkgs ? import <nixpkgs> {},
+  lib ? pkgs.lib,
+  buildGoModule ? pkgs.buildGoModule,
+  ...
+}:
 
 buildGoModule {
   pname = "dogemap";

--- a/pkgs/dogenet/default.nix
+++ b/pkgs/dogenet/default.nix
@@ -1,4 +1,9 @@
-{ lib, pkgs, stdenv, fetchurl, buildGoModule, ... }:
+{
+  pkgs ? import <nixpkgs> {},
+  lib ? pkgs.lib,
+  buildGoModule ? pkgs.buildGoModule,
+  ...
+}:
 
 buildGoModule {
   pname = "dogenet";
@@ -6,6 +11,7 @@ buildGoModule {
 
   src = fetchGit {
     url = "https://github.com/dogeorg/dogenet.git";
+    rev = "610b952f7389b80b894d00f5290c5e0861c429c4";
   };
 
   vendorHash = "sha256-5R+5XQZG6Qjk5m2/Oxq4c4qKbxDcnYz57jdNr8ImcqI=";

--- a/pkgs/gigawallet/default.nix
+++ b/pkgs/gigawallet/default.nix
@@ -1,4 +1,10 @@
-{ lib, pkgs, stdenv, fetchurl, buildGoModule, ... }:
+{
+  pkgs ? import <nixpkgs> {},
+  lib ? pkgs.lib,
+  stdenv ? pkgs.stdenv,
+  buildGoModule ? pkgs.buildGoModule,
+  ...
+}:
 
 buildGoModule {
   pname = "gigawallet";

--- a/pkgs/jampuppy/default.nix
+++ b/pkgs/jampuppy/default.nix
@@ -1,4 +1,10 @@
-{ lib, pkgs, stdenv, fetchurl, buildGoModule, ... }:
+{
+  pkgs ? import <nixpkgs> {},
+  lib ? pkgs.lib,
+  stdenv ? pkgs.stdenv,
+  buildGoModule ? pkgs.buildGoModule,
+  ...
+}:
 
 buildGoModule {
   pname = "jampuppy";

--- a/pkgs/libdogecoin/default.nix
+++ b/pkgs/libdogecoin/default.nix
@@ -1,4 +1,10 @@
-{ lib, pkgs, stdenv, fetchurl, ... }:
+{
+  pkgs ? import <nixpkgs> {},
+  lib ? pkgs.lib,
+  stdenv ? pkgs.stdenv,
+  fetchurl ? pkgs.fetchurl,
+  ...
+}:
 
 stdenv.mkDerivation rec {
   pname = "libdogecoin";

--- a/pkgs/nrpe/default.nix
+++ b/pkgs/nrpe/default.nix
@@ -1,4 +1,9 @@
-{ pkgs, stdenv, fetchurl, ... }:
+{
+  pkgs ? import <nixpkgs> {},
+  stdenv ? pkgs.stdenv,
+  fetchurl ? pkgs.fetchurl,
+  ...
+}:
 
 stdenv.mkDerivation rec {
   pname = "nrpe";

--- a/pkgs/radicle-httpd/default.nix
+++ b/pkgs/radicle-httpd/default.nix
@@ -1,12 +1,18 @@
-{ pkgs, stdenv, fetchurl, ... }:
+{
+  pkgs ? import <nixpkgs> {},
+  lib ? pkgs.lib,
+  stdenv ? pkgs.stdenv,
+  fetchurl ? pkgs.fetchurl,
+  ...
+}:
 
 stdenv.mkDerivation rec {
   pname = "radicle-httpd";
-  version = "0.15.0";
+  version = "0.17.0";
 
   src = fetchurl {
     url = "https://files.radicle.xyz/releases/${pname}/latest/${pname}-${version}-x86_64-unknown-linux-musl.tar.xz";
-    hash = "sha256-UOtq1QMnwu4r/rTR3LVOuikHgNgY+0/Zj+254a+rO7A=";
+    hash = "sha256-SW/hgHGzA6FLmZHNzkIoome2cMaZcpQGTHyEc33cCuY=";
   };
 
   installPhase = ''

--- a/pkgs/radicle/default.nix
+++ b/pkgs/radicle/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "radicle";
-  version = "1.0.0-rc.13";
+  version = "1.0.0";
 
   src = fetchurl {
     url = "https://files.radicle.xyz/releases/latest/${pname}-${version}-x86_64-unknown-linux-musl.tar.xz";
-    hash = "sha256-8l2O2DSLrdIGe3isQoS1MiJPT2MsBUIwiastFgHScIE=";
+    hash = "sha256-btJnbw7/xyBrAe3imfhXrEfOx8HJvEQpuCb8ajWLTig=";
   };
 
   installPhase = ''


### PR DESCRIPTION
This adds defaults to all the nix imports so you can just run `nix-build` without having to pass things into them.

This also upgrades `radicle` to non-RC `1.0.0`, and `radicle-httpd` to `0.17.0`