### PR TITLE
lib: added -levent_core for event_extra check

### DIFF
--- a/pkgs/libdogecoin/default.nix
+++ b/pkgs/libdogecoin/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   configurePhase = ''
     export HOME=$(pwd)
     ./autogen.sh
-    ./configure
+    LIBS="-levent_core" ./configure
   '';
 
   installPhase = ''


### PR DESCRIPTION
Added `LIBS="-levent_core"` during the `configurePhase` to ensure that `-levent_core` is linked when checking for `libevent_extra`.